### PR TITLE
General cleanup and dependency analysis

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,18 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="KotlinBigDecimalEquals" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="MemberVisibilityCanBePrivate" enabled="true" level="WEAK WARNING" enabled_by_default="false">
+      <scope name="Production" level="WEAK WARNING" enabled="true" />
+    </inspection_tool>
+    <inspection_tool class="PublicApiImplicitType" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="RedundantValueArgument" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="ReplaceCollectionCountWithSize" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="ReplaceNotNullAssertionWithElvisReturn" enabled="true" level="WEAK WARNING" enabled_by_default="false">
+      <scope name="Production" level="WEAK WARNING" enabled="true" />
+    </inspection_tool>
+    <inspection_tool class="ReplacePrintlnWithLogging" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ReplaceUntilWithRangeUntil" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="WhenWithOnlyElse" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
     id("io.gitlab.arturbosch.detekt")
-//    id("com.autonomousapps.dependency-analysis")
+    id("com.autonomousapps.dependency-analysis")
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
     jacoco
 }
@@ -68,10 +68,10 @@ kotlin {
     jvmToolchain(8)
 }
 
-//dependencyAnalysis {
-//    usage {
-//        analysis {
-//            checkSuperClasses(true) // false by default
-//        }
-//    }
-//}
+dependencyAnalysis {
+    usage {
+        analysis {
+            checkSuperClasses(true) // false by default
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ jimfsVersion = 1.3.1
 # quality
 detektVersion = 1.23.8
 jacocoVersion = 0.8.13
-#daVersion = 2.19.0
+daVersion=3.0.1
 bcvVersion = 0.18.1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,12 +2,12 @@ pluginManagement {
     plugins {
         val kotlinVersion: String by settings
         val detektVersion: String by settings
-        //val daVersion: String by settings
+        val daVersion: String by settings
         val bcvVersion: String by settings
         kotlin("jvm") version kotlinVersion
         kotlin("plugin.serialization") version kotlinVersion
         id("io.gitlab.arturbosch.detekt") version detektVersion
-        //id("com.autonomousapps.dependency-analysis") version daVersion
+        id("com.autonomousapps.dependency-analysis") version daVersion
         id("org.jetbrains.kotlinx.binary-compatibility-validator") version bcvVersion
     }
     repositories {

--- a/src/main/kotlin/eu/pieland/delta/DeltaCreatorChecksums.kt
+++ b/src/main/kotlin/eu/pieland/delta/DeltaCreatorChecksums.kt
@@ -17,7 +17,7 @@ internal class DeltaCreatorHashes(initialSize: Int = 256, private val loadFactor
 
     init {
         require(loadFactor > 0f && loadFactor < 1f) { "'loadFactor' must be > 0 and < 1: $loadFactor" }
-        require(initialSize <= MAX_TABLE_SIZE && initialSize > 0 && ((initialSize and (initialSize - 1)) == 0)) {
+        require(initialSize in 1..MAX_TABLE_SIZE && ((initialSize and (initialSize - 1)) == 0)) {
             "'initialCapacity' must be a power of 2 > 0 and <= $MAX_TABLE_SIZE: $initialSize"
         }
     }

--- a/src/test/kotlin/eu/pieland/delta/TemporaryFileHook.kt
+++ b/src/test/kotlin/eu/pieland/delta/TemporaryFileHook.kt
@@ -23,7 +23,7 @@ internal class TemporaryFileHook : ResolveParameterHook {
 
     private fun createTempFile(): Path = Files.createTempDirectory("deltaPropertyTest")
 
-    private inner class ClosingFile(val file: Path) : CloseOnReset {
+    private class ClosingFile(val file: Path) : CloseOnReset {
 
         @OptIn(ExperimentalPathApi::class)
         override fun close() {


### PR DESCRIPTION
- Replace redundant `require` range check with `in` operator for `initialSize`.
- Fully enable Dependency Analysis Plugin. (to see if the pipeline can now build it)
- Update inspection profiles with additional rules.
- Remove unnecessary `inner` modifier in `ClosingFile`.
- Bump `dependency-analysis` plugin version to `3.0.1`.