### PR TITLE
Fix patch ordering and generator for case-insensitive filesystems

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/src/main/kotlin/eu/pieland/delta/DeltaPatcher.kt
+++ b/src/main/kotlin/eu/pieland/delta/DeltaPatcher.kt
@@ -44,9 +44,9 @@ internal class DeltaPatcher(private val zipPatch: ZipInputStream, private val ta
 
     fun patch(): Path {
         unchanged.check()
+        deleted.delete()
         created.create()
         updated.update()
-        deleted.delete()
         return target
     }
 

--- a/src/test/kotlin/eu/pieland/delta/DeltaHappyFlowPropertyTest.kt
+++ b/src/test/kotlin/eu/pieland/delta/DeltaHappyFlowPropertyTest.kt
@@ -35,7 +35,15 @@ internal object DeltaHappyFlowPropertyTest {
                 random.repeat(randomCount) + same.repeat(sameCount)
             }.map { it.toByteArray() }
 
-        return Arbitraries.maps(completeFilenames, fileContents).uniqueKeys { it.invariantSeparatorsPathString }
+        val isCaseInsensitive = !System.getProperty("os.name")
+            .lowercase()
+            .contains("linux")
+
+        return Arbitraries.maps(completeFilenames, fileContents)
+            .uniqueKeys {
+                val path = it.invariantSeparatorsPathString
+                if (isCaseInsensitive) path.lowercase() else path
+            }
             .ofSize(0..5).withSizeDistribution(RandomDistribution.biased())
     }
 


### PR DESCRIPTION
on macOS case-insensitive APFS, DeltaPatcher tries to CREATE a.9 before DELETING A.9, which are the same file, causing CREATED file already exists.

fix 1: swap delete before create in DeltaPatcher.patch()
fix 2: make uniqueKeys case-insensitive on non-Linux systems so the generator never produces impossible states
  